### PR TITLE
Add commas to modal.mustache example json to make it valid

### DIFF
--- a/templates/modal.mustache
+++ b/templates/modal.mustache
@@ -29,16 +29,15 @@
 
     Example context (json):
     {
-        "elementid": "exampleId"
+        "elementid": "exampleId",
         "buttons": [
           {"id": "randomid"},
-          {"imageClass": "c4l-classname"}
-          {"name": "component name"}
+          {"imageClass": "c4l-classname"},
+          {"name": "component name"},
           {"htmlcode": "<div>Text</div>"}
-        ],
+        ]
     }
 }}
-
 {{< core/modal }}
     {{$title}}
         {{#str}} pluginname, tiny_c4l {{/str}}


### PR DESCRIPTION
There is no functional change but I was passing it through the mustache validator in moodle-ci and it threw an error. It might remove some spurious errors if you start using https://github.com/moodlehq/moodle-plugin-ci in the future. At the moment it doesn't even recognise the tiny plugin type, but I expect that will be fixed in the near future.